### PR TITLE
Tweak Travis settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: c
 env:
   global:
-    - GAPROOT=gaproot
-    - COVDIR=coverage
     - GAP_BOOTSTRAP=minimal
-    - GAP_PKGS_TO_CLONE="json io crypting curlInterface profiling"
-    - GAP_PKGS_TO_BUILD="json io crypting curlInterface profiling"
+    - GAP_PKGS_TO_CLONE="json crypting curlInterface"
+    - GAP_PKGS_TO_BUILD="io profiling json crypting curlInterface"
 
 branches:
   except:
@@ -13,35 +11,34 @@ branches:
 
 addons:
   apt_packages:
+    - libcurl4-openssl-dev
     - libgmp-dev
     - libreadline-dev
+    - zlib1g-dev
     - texlive-latex-extra
     - texlive-fonts-recommended
 
 matrix:
   include:
-    - env: GAPBRANCH="stable-4.10"
-    - env: CFLAGS="-O2"
-      compiler: gcc
-    - env: CFLAGS="-O2" CC=clang CXX=clang++
-      compiler: clang
+    - env: GAPBRANCH=stable-4.10
+    - env: GAPBRANCH=master
     - env: ABI=32
       addons:
         apt_packages:
           - libcurl4-openssl-dev:i386
           - libgmp-dev:i386
           - libreadline-dev:i386
+          - zlib1g-dev:i386
           - texlive-latex-extra:i386
           - texlive-fonts-recommended:i386
           - gcc-multilib
           - g++-multilib
 
 before_script:
-  - export GAPROOT="$HOME/gap"
   - git clone https://github.com/gap-system/pkg-ci-scripts.git scripts
   - scripts/build_gap.sh
 script:
   - scripts/build_pkg.sh && scripts/run_tests.sh
 after_script:
-  - bash scripts/gather-coverage.sh
+  - scripts/gather-coverage.sh
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
- this package contains no compiled code, so there is no point in
  testing with different C/C++ compilers
- change the test using the GAP master branch to make it explicit that master
  is tested, by setting GAPBRANCH="master"
- add zlib1g-dev to installed dependencies, so that GAP does not need
  to compile its own
- don't use dev versions of io and profiling
- get rid of obsolete environment variables