### PR TITLE
Alternative test suite without MongoDB requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
     - GAP_BOOTSTRAP=minimal
     - GAP_PKGS_TO_CLONE="json io crypting curlInterface profiling"
     - GAP_PKGS_TO_BUILD="json io crypting curlInterface profiling"
+    - GAP_TESTFILE=tst/testall.g  # to be explicit
 
 branches:
   except:

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -100,7 +100,7 @@ AvailabilityTest := function()
         return true;
     end,
 
-TestFile := "tst/testall.g",
+TestFile := "tst/test-without-mongodb.g",
 
 #Keywords := [ "TODO" ],
 

--- a/tst/test-without-mongodb.g
+++ b/tst/test-without-mongodb.g
@@ -1,0 +1,9 @@
+#
+# Memoisation: Shared persistent memoisation library for GAP and other systems
+#
+# This file runs package tests *excluding* MongoDBCache.tst.  This is for
+# systems that can't run a local MongoDB service but still want to test the rest
+# of the package.
+#
+MEMO_ExcludeTestFiles := ["MongoDBCache.tst"];
+Read(Filename(DirectoriesPackageLibrary("Memoisation", "tst")[1], "testall.g"));

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -26,9 +26,15 @@ compareFunction := function(expected, found)
   return expected = found;
 end;
 
+# Any files to exclude?
+if not IsBound(MEMO_ExcludeTestFiles) then
+  MEMO_ExcludeTestFiles := [];
+fi;
+
 TestDirectory(DirectoriesPackageLibrary( "Memoisation", "tst" ),
               rec(exitGAP := true,
                   rewriteToFile := false,
+                  exclude := MEMO_ExcludeTestFiles,
                   testOptions := rec(compareFunction := compareFunction)));
 
 FORCE_QUIT_GAP(1); # if we ever get here, there was an error


### PR DESCRIPTION
This PR adds `tst/test-without-mongodb.g`, an alternative to `tst/testall.g` that runs all the tests except those that require MongoDB/Eve.

@alex-konovalov: can Docker be configured to execute this file instead of `tst/testall.g`?  If so, this fixes Issue #5.